### PR TITLE
Fix some bugs in v1.0 of MechOverhaul

### DIFF
--- a/items/liquids/unrefinedliquidmechfuel.liqitem
+++ b/items/liquids/unrefinedliquidmechfuel.liqitem
@@ -6,5 +6,5 @@
   "shortdescription" : "Unrefined Fuel",
   "description" : "Unrefined mech fuel obtained from primitive oil.",
 
-  "liquid" : "mechfuel"
+  "liquid" : "unrefinedmechfuel"
 }

--- a/liquids/unrefinedmechfuel.liquid
+++ b/liquids/unrefinedmechfuel.liquid
@@ -1,11 +1,11 @@
 {
-  "name" : "mechfuel",
-  "liquidId" : 29,
-  "description" : "Refined mech fuel.",
+  "name" : "unrefinedmechfuel",
+  "liquidId" : 28,
+  "description" : "Unrefined mech fuel.",
   "tickDelta" : 1,
-  "color" : [255, 255, 0, 140],
+  "color" : [240, 180, 80, 185],
   "statusEffects" : [ "swimming" ],
-  "itemDrop" : "liquidmechfuel",
+  "itemDrop" : "unrefinedliquidmechfuel",
 
   "interactions" : [
     {
@@ -19,10 +19,6 @@
     {
       "liquid" : 5,
       "liquidResult" : 5
-    },
-    {
-      "liquid" : 28,
-      "liquidResult" : 28
     }
   ],
 

--- a/vehicles/modularmech/mechpartmanager.lua
+++ b/vehicles/modularmech/mechpartmanager.lua
@@ -244,7 +244,6 @@ function MechPartManager:buildVehicleParameters(itemSet, primaryColorIndex, seco
   end
 
   mass = math.floor(mass * 10) / 10
-  params.parts.body.totalMass = mass
   --end
 
   --calculating health bonus and speed nerf based on mass and protection
@@ -255,6 +254,8 @@ function MechPartManager:buildVehicleParameters(itemSet, primaryColorIndex, seco
   --level6: 877
   --level7: 902
   if params.parts.body then
+    params.parts.body.totalMass = mass
+
     local initialBonus = 10
     local maxHealthBonus = params.parts.body.energyMax * 0.5
     local initialMass = 12


### PR DESCRIPTION
* Fixed a bug that crashes the mechpartmanager if the user removes the
  mech body.
* Fixed a bug that allowed the user to instantly create refined mech
  fuel for free by dumping unrefined mech fuel into an enclosed
  container and then sucking it back up with the matter manipulator.
* Fixed an unnecessary incompatibility with the "mORE Liquids" mod which
  had already registered liquidId 20. I set mechfuel to use the
  unregistered liquidId 29 and the new unrefinedmechfuel to use liquidId
  28. The only possible negative effect of this fix is that if a user
  has created a lake of mechfuel; the lake will disappear when this
  bugfix is installed. In the future to avoid incompatibility among
  mods, please check https://starbounder.org/Modding:Liquids:Mods for
  unregistered IDs and don't forget to register your IDs once you've
  published your mod.

A couple of bonus improvements:

* Add the swimming statusEffect to both liquids. This does nothing in general, but if the user has the Improved Swim Physics mod installed, it will allow improved swimming in those liquids.
* Added liquid interactions. If either refined or unrefined mech fuel touches lava, it turns into lava. If refined mech fuel is "polluted" with unrefined mech fuel or oil, it turns into that lesser liquid.