### PR TITLE
Crash-bug fix, minor fixes, fuel balancing

### DIFF
--- a/interface/catalystfuelrefinery/refinery.lua
+++ b/interface/catalystfuelrefinery/refinery.lua
@@ -63,7 +63,7 @@ function insertFuel()
 end
 
 function insertCatalyst()
-if self.disabled then return end
+  if self.disabled then return end
 
   swapItem("itemSlot_catalystInput", false, "fuelcatalyst", "setCatalystInputItem2")
 end
@@ -81,12 +81,13 @@ function refine()
   local fuelInput = widget.itemSlotItem("itemSlot_input")
   local catalystInput = widget.itemSlotItem("itemSlot_catalystInput")
 
-  if not fuelInput or not catalystInput then return end
+  if not fuelInput or fuelInput.count < 10 or not catalystInput or catalystInput.count < 1 then return end
 
-  if catalystInput.count >= fuelInput.count / 10 then
-    self.itemsLeft = fuelInput.count
-  elseif catalystInput.count < fuelInput.count / 10 and catalystInput.count > 0 then
-    self.itemsLeft = fuelInput.count - catalystInput.count
+  local fuelInputCount = math.floor(fuelInput.count / 10)
+  if catalystInput.count >= fuelInputCount then
+    self.itemsLeft = fuelInputCount
+  else
+    self.itemsLeft = catalystInput.count
   end
 end
 
@@ -105,7 +106,7 @@ function swapItem(widgetName, output, inputItem, message)
         swapItem.count = itemCount
       end
     end
-    
+
     player.setSwapSlotItem(currentItem)
     widget.setItemSlotItem(widgetName, swapItem)
   elseif not swapItem and not output then
@@ -139,27 +140,29 @@ function craftItem()
     return
   end
 
-  if fuelItem.count >= 10 and catalystItem.count > 1 then
+  if fuelItem.count > 10 then
     fuelItem.count = fuelItem.count - 10
-    catalystItem.count = catalystItem.count - 1
-  elseif fuelItem.count == 10 and catalystItem then
-     fuelItem = nil
-     catalystItem.count = catalystItem.count - 1
-     self.itemsLeft = 0
-  elseif catalystItem.count == 1 and fuelItem and fuelItem.count >= 10 then
-    fuelItem.count = fuelItem.count - 10
-    catalystItem = nil
+  elseif fuelItem.count == 10 then
+    fuelItem = nil
+  else
     self.itemsLeft = 0
-  elseif not fuelItem or fuelItem.count < 10 or not catalystItem or catalystItem.count < 1 then
+    return
+  end
+
+  if catalystItem.count > 1 then
+    catalystItem.count = catalystItem.count - 1
+  elseif catalystItem.count == 1 then
+    catalystItem = nil
+  else
     self.itemsLeft = 0
     return
   end
 
   if not outputItem then
     outputItem = {name = "liquidmechfuel", count = 10}
-  elseif outputItem and outputItem.count < 1000 then
+  elseif outputItem.count <= 990 then
     outputItem.count = outputItem.count + 10
-  elseif outputItem and outputItem.count == 1000 then
+  else
     self.itemsLeft = 0
     return
   end

--- a/scripts/deployment/playermechdeployment.lua
+++ b/scripts/deployment/playermechdeployment.lua
@@ -31,8 +31,8 @@ function init()
     end)
 
   message.setHandler("getMechParams", function()
-	  return self.mechParameters
-  end)
+      return self.mechParameters
+    end)
 
 
   message.setHandler("setMechItemSet", function(_, _, newItemSet)
@@ -144,8 +144,6 @@ function init()
 
   -- block movement abilities during these ticks to avoid weirdness with techs, etc.
   status.setPersistentEffects("mechDeployment", {{stat = "activeMovementAbilities", amount = 1}})
-
-  --player.interact("ScriptPane", "/interface/mechfuel/mechfuel.config", storage.vehicleId)
 end
 
 function setMechItemSet(newItemSet)
@@ -167,7 +165,7 @@ function update(dt)
   --setting the max fuel count for arithmetics on dummy quest
   if self.mechParameters then
     local energyMax = self.mechParameters.parts.body.energyMax
-	  world.sendEntityMessage(self.playerId, "setCurrentMaxFuel", energyMax)
+    world.sendEntityMessage(self.playerId, "setCurrentMaxFuel", energyMax)
   end
 
   if self.deployTicks then
@@ -184,9 +182,9 @@ function update(dt)
           deploy(tempItemSet, tempPrimaryColorIndex, tempSecondaryColorIndex)
 
           --setting fuel for temp mech items
-		      local energyMax = self.mechParameters.parts.body.energyMax
-          world.sendEntityMessage(self.playerId, "setFuelType", "Mech fuel")
-		      world.sendEntityMessage(self.playerId, "setQuestFuelCount", energyMax)
+          local energyMax = self.mechParameters.parts.body.energyMax
+          world.sendEntityMessage(self.playerId, "setFuelType", "Mech Fuel")
+          world.sendEntityMessage(self.playerId, "setQuestFuelCount", energyMax)
           --end
 
           return true
@@ -231,18 +229,18 @@ function update(dt)
       self.energyCheck = nil
     end
 
-	--getting mech health from vehicle entity
-	if not self.healthCheck then
+    --getting mech health from vehicle entity
+    if not self.healthCheck then
       self.healthCheck = world.sendEntityMessage(storage.vehicleId, "currentHealth")
     end
 
-	if self.healthCheck and self.healthCheck:finished() then
+    if self.healthCheck and self.healthCheck:finished() then
       if self.healthCheck:succeeded() then
         self.mechHealthRatio = self.healthCheck:result()
       end
       self.healthCheck = nil
     end
-	--end
+    --end
   end
 
   --health bar variables
@@ -260,19 +258,19 @@ function update(dt)
         self.lowEnergyTimer = self.lowEnergyTime
       end
 
-	  --play low health sound
-	  if self.mechHealthRatio < self.lowHealthThreshold and self.lowHealthTimer == 0 then
-      localAnimator.playAudio(self.lowEnergySound)
-      self.lowHealthTimer = self.lowHealthTime
-    end
-	  --end
+      --play low health sound
+      if self.mechHealthRatio < self.lowHealthThreshold and self.lowHealthTimer == 0 then
+        localAnimator.playAudio(self.lowEnergySound)
+        self.lowHealthTimer = self.lowHealthTime
+      end
+      --end
 
-    drawEnergyBar()
-  	--draw health bar
-  	drawHealthBar()
-  	--end
-    drawEnemyIndicators()
-  end
+      drawEnergyBar()
+      --draw health bar
+      drawHealthBar()
+      --end
+      drawEnemyIndicators()
+    end
 
     if self.beaconPosition then
       self.beaconFlashTimer = (self.beaconFlashTimer + dt) % self.beaconFlashTime
@@ -287,7 +285,7 @@ function uninit()
   if inMech() then
     storage.inMechWithEnergyRatio = self.mechEnergyRatio
     --modded
-	  storage.inMechWithHealthRatio = self.mechHealthRatio
+    storage.inMechWithHealthRatio = self.mechHealthRatio
     --end
     storage.inMechWithWorldType = world.type()
   end
@@ -377,13 +375,13 @@ function drawEnergyBar()
   if fuelType == "Oil" then
     imageFrame = "/scripts/deployment/energybarframeoil.png"
     imageBar =  "/scripts/deployment/energybaroil.png"
-  elseif fuelType == "Mech fuel" then
+  elseif fuelType == "Mech Fuel" then
     imageFrame = "/scripts/deployment/energybarframemechfuel.png"
     imageBar =  "/scripts/deployment/energybarmechfuel.png"
   elseif fuelType == "Erchius" then
     imageFrame = "/scripts/deployment/energybarframe.png"
     imageBar =  "/scripts/deployment/energybar.png"
-  elseif fuelType == "Unrefined" then
+  elseif fuelType == "Unrefined Fuel" then
     imageFrame = "/scripts/deployment/energybarframeunrefinedfuel.png"
     imageBar =  "/scripts/deployment/energybarunrefinedfuel.png"
   else


### PR DESCRIPTION
I fixed a crash-bug that was causing a race-condition segfault if the
mech fuel window was left open when beaming up/down. During beaming, if
the update function ran, there was a change that player.id() would
return 0, causing world.sendEntityMessage to segfault.

Another change I made to mechfuel.lua was to centralize all of the info
about fuels into a table defined in the init function to avoid
repetition.  The current breakdown I've been experimenting with is
oil=1, liquid erchius=1.8, solid erchius=3.6, unrefinedmechfuel=4, and
mechfuel=8. I realize that 8:1 seems a little over-powered, but I was
experimenting with setting fuel to 0 if the mech explodes to offset
this, when I discovered and fixed the crash-bug described above. If you
want, you can modify the table to return the ratios to what they were
before.

Another smaller bugfix in mechfuel.lua was that, in the old code, if you
had 799/800 fuel and 1000 oil in the fuel slot, when you clicked fuel
your fuel rose to 800/800 fuel, but your oil went to 499. I simplified
the logic around refueling to fix this, although the bug symptons have
been masked by the ratio changes I described above.

One final change included in the above mechfuel.lua changes the names
'Mech fuel' and 'Unrefined' to be 'Mech Fuel' and 'Unrefined Fuel'
respectively, to make them more consistent with other uses of those
names.

I fixed a small bug in catalystfuelrefinery that, if you had a stack of
999 mech fuel, the next refining would reduce your unrefined input by
10, but would produce only 1 new mech fuel. I fixed it so that refining
stops if your stack of mech fuel is >990.

I changed the logic in mechfuelrefinery to mirror that of
catalystfuelrefinery for consistency.

Finally, there were a mix of tabs and spaces in the source files that
were making indentation weird. I fixed it by switching to all spaces.